### PR TITLE
Feature/enable sync label cm operator

### DIFF
--- a/deploy/cluster-manager/chart/cluster-manager/templates/operator.yaml
+++ b/deploy/cluster-manager/chart/cluster-manager/templates/operator.yaml
@@ -37,6 +37,9 @@ spec:
         args:
           - "/registration-operator"
           - "hub"
+          {{- if .Values.enableSyncLabels }}
+          - --enable-sync-labels
+          {{- end }}
         env:
         - name: POD_NAME
           valueFrom:

--- a/deploy/cluster-manager/chart/cluster-manager/values.yaml
+++ b/deploy/cluster-manager/chart/cluster-manager/values.yaml
@@ -78,6 +78,9 @@ affinity:
                 values:
                   - cluster-manager
 
+# enableSyncLabels for clusterManager operator deployment.
+enableSyncLabels: true
+
 # if true, will create a bootstrap secret for cluster join and auto approve.
 createBootstrapToken: false
 

--- a/deploy/cluster-manager/chart/cluster-manager/values.yaml
+++ b/deploy/cluster-manager/chart/cluster-manager/values.yaml
@@ -79,7 +79,7 @@ affinity:
                   - cluster-manager
 
 # enableSyncLabels for clusterManager operator deployment.
-enableSyncLabels: true
+enableSyncLabels: false
 
 # if true, will create a bootstrap secret for cluster join and auto approve.
 createBootstrapToken: false

--- a/manifests/cluster-manager/hub/0000_00_addon.open-cluster-management.io_clustermanagementaddons.crd.yaml
+++ b/manifests/cluster-manager/hub/0000_00_addon.open-cluster-management.io_clustermanagementaddons.crd.yaml
@@ -2,6 +2,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clustermanagementaddons.addon.open-cluster-management.io
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 spec:
   group: addon.open-cluster-management.io
   names:

--- a/manifests/cluster-manager/hub/0000_00_clusters.open-cluster-management.io_managedclusters.crd.yaml
+++ b/manifests/cluster-manager/hub/0000_00_clusters.open-cluster-management.io_managedclusters.crd.yaml
@@ -2,6 +2,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: managedclusters.cluster.open-cluster-management.io
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 spec:
   group: cluster.open-cluster-management.io
   names:

--- a/manifests/cluster-manager/hub/0000_00_clusters.open-cluster-management.io_managedclustersets.crd.yaml
+++ b/manifests/cluster-manager/hub/0000_00_clusters.open-cluster-management.io_managedclustersets.crd.yaml
@@ -2,6 +2,13 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: managedclustersets.cluster.open-cluster-management.io
+  labels:
+    app: clustermanager-controller
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 spec:
   group: cluster.open-cluster-management.io
   names:

--- a/manifests/cluster-manager/hub/0000_00_multicluster.x-k8s.io_clusterprofiles.crd.yaml
+++ b/manifests/cluster-manager/hub/0000_00_multicluster.x-k8s.io_clusterprofiles.crd.yaml
@@ -5,6 +5,12 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
   name: clusterprofiles.multicluster.x-k8s.io
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 spec:
   group: multicluster.x-k8s.io
   names:

--- a/manifests/cluster-manager/hub/0000_00_work.open-cluster-management.io_manifestworkreplicasets.crd.yaml
+++ b/manifests/cluster-manager/hub/0000_00_work.open-cluster-management.io_manifestworkreplicasets.crd.yaml
@@ -2,6 +2,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: manifestworkreplicasets.work.open-cluster-management.io
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 spec:
   group: work.open-cluster-management.io
   names:

--- a/manifests/cluster-manager/hub/0000_00_work.open-cluster-management.io_manifestworks.crd.yaml
+++ b/manifests/cluster-manager/hub/0000_00_work.open-cluster-management.io_manifestworks.crd.yaml
@@ -2,6 +2,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: manifestworks.work.open-cluster-management.io
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 spec:
   group: work.open-cluster-management.io
   names:

--- a/manifests/cluster-manager/hub/0000_01_addon.open-cluster-management.io_managedclusteraddons.crd.yaml
+++ b/manifests/cluster-manager/hub/0000_01_addon.open-cluster-management.io_managedclusteraddons.crd.yaml
@@ -2,6 +2,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: managedclusteraddons.addon.open-cluster-management.io
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 spec:
   group: addon.open-cluster-management.io
   names:

--- a/manifests/cluster-manager/hub/0000_01_clusters.open-cluster-management.io_managedclustersetbindings.crd.yaml
+++ b/manifests/cluster-manager/hub/0000_01_clusters.open-cluster-management.io_managedclustersetbindings.crd.yaml
@@ -2,6 +2,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: managedclustersetbindings.cluster.open-cluster-management.io
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 spec:
   group: cluster.open-cluster-management.io
   names:

--- a/manifests/cluster-manager/hub/0000_02_addon.open-cluster-management.io_addondeploymentconfigs.crd.yaml
+++ b/manifests/cluster-manager/hub/0000_02_addon.open-cluster-management.io_addondeploymentconfigs.crd.yaml
@@ -2,6 +2,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: addondeploymentconfigs.addon.open-cluster-management.io
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 spec:
   group: addon.open-cluster-management.io
   names:

--- a/manifests/cluster-manager/hub/0000_02_clusters.open-cluster-management.io_placements.crd.yaml
+++ b/manifests/cluster-manager/hub/0000_02_clusters.open-cluster-management.io_placements.crd.yaml
@@ -2,6 +2,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: placements.cluster.open-cluster-management.io
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 spec:
   group: cluster.open-cluster-management.io
   names:

--- a/manifests/cluster-manager/hub/0000_03_addon.open-cluster-management.io_addontemplates.crd.yaml
+++ b/manifests/cluster-manager/hub/0000_03_addon.open-cluster-management.io_addontemplates.crd.yaml
@@ -3,6 +3,12 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   name: addontemplates.addon.open-cluster-management.io
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 spec:
   group: addon.open-cluster-management.io
   names:

--- a/manifests/cluster-manager/hub/0000_03_clusters.open-cluster-management.io_placementdecisions.crd.yaml
+++ b/manifests/cluster-manager/hub/0000_03_clusters.open-cluster-management.io_placementdecisions.crd.yaml
@@ -2,6 +2,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: placementdecisions.cluster.open-cluster-management.io
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 spec:
   group: cluster.open-cluster-management.io
   names:

--- a/manifests/cluster-manager/hub/0000_05_clusters.open-cluster-management.io_addonplacementscores.crd.yaml
+++ b/manifests/cluster-manager/hub/0000_05_clusters.open-cluster-management.io_addonplacementscores.crd.yaml
@@ -2,6 +2,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: addonplacementscores.cluster.open-cluster-management.io
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 spec:
   group: cluster.open-cluster-management.io
   names:

--- a/manifests/cluster-manager/hub/cluster-manager-addon-manager-clusterrole.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-addon-manager-clusterrole.yaml
@@ -2,6 +2,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: open-cluster-management:{{ .ClusterManagerName }}-addon-manager:controller
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 rules:
 # Allow controller to get/list/watch/create/delete configmaps/events
 - apiGroups: [""]

--- a/manifests/cluster-manager/hub/cluster-manager-addon-manager-clusterrolebinding.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-addon-manager-clusterrolebinding.yaml
@@ -2,6 +2,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: open-cluster-management:{{ .ClusterManagerName }}-addon-manager:controller
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/cluster-manager/hub/cluster-manager-addon-manager-serviceaccount.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-addon-manager-serviceaccount.yaml
@@ -3,3 +3,9 @@ kind: ServiceAccount
 metadata:
   name: addon-manager-controller-sa
   namespace: {{ .ClusterManagerNamespace }}
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}

--- a/manifests/cluster-manager/hub/cluster-manager-addon-manager-work-executor-admin-clusterrolebinding.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-addon-manager-work-executor-admin-clusterrolebinding.yaml
@@ -2,6 +2,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: open-cluster-management:{{ .ClusterManagerName }}-addon-manager-work-executor:controller
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/cluster-manager/hub/cluster-manager-manifestworkreplicaset-clusterrole.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-manifestworkreplicaset-clusterrole.yaml
@@ -2,6 +2,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: open-cluster-management:{{ .ClusterManagerName }}-work:controller
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 rules:
 - apiGroups: [ "" ]
   resources: [ "configmaps"]

--- a/manifests/cluster-manager/hub/cluster-manager-manifestworkreplicaset-clusterrolebinding.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-manifestworkreplicaset-clusterrolebinding.yaml
@@ -2,6 +2,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: open-cluster-management:{{ .ClusterManagerName }}-work:controller
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/cluster-manager/hub/cluster-manager-manifestworkreplicaset-serviceaccount.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-manifestworkreplicaset-serviceaccount.yaml
@@ -3,3 +3,9 @@ kind: ServiceAccount
 metadata:
   name: work-controller-sa
   namespace: {{ .ClusterManagerNamespace }}
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}

--- a/manifests/cluster-manager/hub/cluster-manager-placement-clusterrole.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-placement-clusterrole.yaml
@@ -2,6 +2,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: open-cluster-management:{{ .ClusterManagerName }}-placement:controller
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 rules:
 # Allow controller to get/list/watch/create/delete configmaps
 - apiGroups: [""]

--- a/manifests/cluster-manager/hub/cluster-manager-placement-clusterrolebinding.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-placement-clusterrolebinding.yaml
@@ -2,6 +2,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: open-cluster-management:{{ .ClusterManagerName }}-placement:controller
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/cluster-manager/hub/cluster-manager-placement-serviceaccount.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-placement-serviceaccount.yaml
@@ -3,3 +3,9 @@ kind: ServiceAccount
 metadata:
   name: placement-controller-sa
   namespace: {{ .ClusterManagerNamespace }}
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}

--- a/manifests/cluster-manager/hub/cluster-manager-registration-clusterrole.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-registration-clusterrole.yaml
@@ -2,6 +2,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: open-cluster-management:{{ .ClusterManagerName }}-registration:controller
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 rules:
 # Allow hub to monitor and update status of csr
 - apiGroups: ["certificates.k8s.io"]

--- a/manifests/cluster-manager/hub/cluster-manager-registration-clusterrolebinding.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-registration-clusterrolebinding.yaml
@@ -2,6 +2,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: open-cluster-management:{{ .ClusterManagerName }}-registration:controller
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/cluster-manager/hub/cluster-manager-registration-serviceaccount.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-registration-serviceaccount.yaml
@@ -10,3 +10,9 @@ metadata:
   annotations:
     eks.amazonaws.com/role-arn-: ""
   {{end}}
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}

--- a/manifests/cluster-manager/hub/cluster-manager-registration-webhook-clusterrole.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-registration-webhook-clusterrole.yaml
@@ -2,6 +2,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: open-cluster-management:{{ .ClusterManagerName }}-registration:webhook
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 rules:
 # Allow managedcluster admission to get/list/watch configmaps
 - apiGroups: [""]

--- a/manifests/cluster-manager/hub/cluster-manager-registration-webhook-clusterrolebinding.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-registration-webhook-clusterrolebinding.yaml
@@ -2,6 +2,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: open-cluster-management:{{ .ClusterManagerName }}-registration:webhook
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/cluster-manager/hub/cluster-manager-registration-webhook-clustersetbinding-validatingconfiguration.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-registration-webhook-clustersetbinding-validatingconfiguration.yaml
@@ -2,6 +2,12 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: managedclustersetbindingvalidators.admission.cluster.open-cluster-management.io
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 webhooks:
 - name: managedclustersetbindingvalidators.admission.cluster.open-cluster-management.io
   failurePolicy: Fail

--- a/manifests/cluster-manager/hub/cluster-manager-registration-webhook-endpoint-hosted.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-registration-webhook-endpoint-hosted.yaml
@@ -3,6 +3,12 @@ apiVersion: v1
 metadata:
   name: cluster-manager-registration-webhook
   namespace: {{ .ClusterManagerNamespace }}
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 subsets:
   - addresses:
       - ip: {{.RegistrationWebhook.Address}}

--- a/manifests/cluster-manager/hub/cluster-manager-registration-webhook-mutatingconfiguration.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-registration-webhook-mutatingconfiguration.yaml
@@ -2,6 +2,12 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: managedclustermutators.admission.cluster.open-cluster-management.io
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 webhooks:
 - name: managedclustermutators.admission.cluster.open-cluster-management.io
   failurePolicy: Fail

--- a/manifests/cluster-manager/hub/cluster-manager-registration-webhook-service-hosted.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-registration-webhook-service-hosted.yaml
@@ -4,6 +4,12 @@ apiVersion: v1
 metadata:
   name: cluster-manager-registration-webhook
   namespace: {{ .ClusterManagerNamespace }}
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 spec:
   type: ClusterIP
   ports:

--- a/manifests/cluster-manager/hub/cluster-manager-registration-webhook-service.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-registration-webhook-service.yaml
@@ -3,6 +3,12 @@ kind: Service
 metadata:
   name: cluster-manager-registration-webhook
   namespace: {{ .ClusterManagerNamespace }}
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 spec:
   selector:
     app: {{ .ClusterManagerName }}-registration-webhook

--- a/manifests/cluster-manager/hub/cluster-manager-registration-webhook-serviceaccount.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-registration-webhook-serviceaccount.yaml
@@ -3,3 +3,9 @@ kind: ServiceAccount
 metadata:
   name: registration-webhook-sa
   namespace: {{ .ClusterManagerNamespace }}
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}

--- a/manifests/cluster-manager/hub/cluster-manager-registration-webhook-validatingconfiguration.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-registration-webhook-validatingconfiguration.yaml
@@ -2,6 +2,12 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: managedclustervalidators.admission.cluster.open-cluster-management.io
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 webhooks:
 - name: managedclustervalidators.admission.cluster.open-cluster-management.io
   failurePolicy: Fail

--- a/manifests/cluster-manager/hub/cluster-manager-work-executor-admin-clusterrole.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-work-executor-admin-clusterrole.yaml
@@ -2,6 +2,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: open-cluster-management:{{ .ClusterManagerName }}-work-executor-admin:webhook
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 rules:
 - apiGroups:
   - work.open-cluster-management.io

--- a/manifests/cluster-manager/hub/cluster-manager-work-webhook-clusterrole.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-work-webhook-clusterrole.yaml
@@ -2,6 +2,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: open-cluster-management:{{ .ClusterManagerName }}-work:webhook
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 rules:
 # Allow managedcluster admission to get/list/watch configmaps
 - apiGroups: [""]

--- a/manifests/cluster-manager/hub/cluster-manager-work-webhook-clusterrolebinding.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-work-webhook-clusterrolebinding.yaml
@@ -2,6 +2,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: open-cluster-management:{{ .ClusterManagerName }}-work:webhook
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/cluster-manager/hub/cluster-manager-work-webhook-endpoint-hosted.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-work-webhook-endpoint-hosted.yaml
@@ -3,6 +3,12 @@ apiVersion: v1
 metadata:
   name: cluster-manager-work-webhook
   namespace: {{ .ClusterManagerNamespace }}
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 subsets:
   - addresses:
       - ip: {{.WorkWebhook.Address}}

--- a/manifests/cluster-manager/hub/cluster-manager-work-webhook-service-hosted.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-work-webhook-service-hosted.yaml
@@ -4,6 +4,12 @@ apiVersion: v1
 metadata:
   name: cluster-manager-work-webhook
   namespace: {{ .ClusterManagerNamespace }}
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 spec:
   type: ClusterIP
   ports:

--- a/manifests/cluster-manager/hub/cluster-manager-work-webhook-service.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-work-webhook-service.yaml
@@ -3,6 +3,12 @@ kind: Service
 metadata:
   name: cluster-manager-work-webhook
   namespace: {{ .ClusterManagerNamespace }}
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 spec:
   selector:
     app: {{ .ClusterManagerName }}-work-webhook

--- a/manifests/cluster-manager/hub/cluster-manager-work-webhook-serviceaccount.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-work-webhook-serviceaccount.yaml
@@ -3,3 +3,9 @@ kind: ServiceAccount
 metadata:
   name: work-webhook-sa
   namespace: {{ .ClusterManagerNamespace }} 
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}

--- a/manifests/cluster-manager/hub/cluster-manager-work-webhook-validatingconfiguration.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-work-webhook-validatingconfiguration.yaml
@@ -2,6 +2,13 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: manifestworkvalidators.admission.work.open-cluster-management.io
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
+
 webhooks:
 - name: manifestworkvalidators.admission.work.open-cluster-management.io
   failurePolicy: Fail

--- a/manifests/cluster-manager/management/cluster-manager-addon-manager-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-addon-manager-deployment.yaml
@@ -5,6 +5,11 @@ metadata:
   namespace: {{ .ClusterManagerNamespace }}
   labels:
     app: clustermanager-controller
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 spec:
   replicas: {{ .Replica }}
   selector:

--- a/manifests/cluster-manager/management/cluster-manager-manifestworkreplicaset-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-manifestworkreplicaset-deployment.yaml
@@ -5,6 +5,11 @@ metadata:
   namespace: {{ .ClusterManagerNamespace }}
   labels:
     app: {{ .ClusterManagerName }}-work-controller
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 spec:
   replicas:  {{ .Replica }}
   selector:

--- a/manifests/cluster-manager/management/cluster-manager-placement-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-placement-deployment.yaml
@@ -5,6 +5,11 @@ metadata:
   namespace: {{ .ClusterManagerNamespace }}
   labels:
     app: clustermanager-controller
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 spec:
   replicas: {{ .Replica }}
   selector:

--- a/manifests/cluster-manager/management/cluster-manager-registration-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-registration-deployment.yaml
@@ -84,6 +84,9 @@ spec:
           {{if .AwsResourceTags}}
           - "--aws-resource-tags={{ .AwsResourceTags }}"
           {{end}}
+          {{ if gt (len .Labels) 0 }}
+          - "--labels={{ .Labels }}"
+          {{ end }}
         env:
           - name: POD_NAME
             valueFrom:

--- a/manifests/cluster-manager/management/cluster-manager-registration-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-registration-deployment.yaml
@@ -5,6 +5,11 @@ metadata:
   namespace: {{ .ClusterManagerNamespace }}
   labels:
     app: clustermanager-controller
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    {{ $key }}: {{ $value }}
+    {{ end }}
+    {{ end }}
 spec:
   replicas: {{ .Replica }}
   selector:

--- a/manifests/cluster-manager/management/cluster-manager-registration-webhook-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-registration-webhook-deployment.yaml
@@ -5,6 +5,11 @@ metadata:
   namespace: {{ .ClusterManagerNamespace }}
   labels:
     app: {{ .ClusterManagerName }}-registration-webhook
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 spec:
   replicas: {{ .Replica }}
   selector:

--- a/manifests/cluster-manager/management/cluster-manager-work-webhook-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-work-webhook-deployment.yaml
@@ -5,6 +5,11 @@ metadata:
   namespace: {{ .ClusterManagerNamespace }}
   labels:
     app: {{ .ClusterManagerName }}-work-webhook
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 spec:
   replicas: {{ .Replica }}
   selector:

--- a/manifests/config.go
+++ b/manifests/config.go
@@ -38,6 +38,7 @@ type HubConfig struct {
 	AutoApprovedCSRUsers              string
 	AutoApprovedARNPatterns           string
 	AwsResourceTags                   string
+	Labels                            map[string]string
 }
 
 type Webhook struct {

--- a/pkg/cmd/hub/operator.go
+++ b/pkg/cmd/hub/operator.go
@@ -28,6 +28,8 @@ func NewHubOperatorCmd() *cobra.Command {
 			"e.g. 'environment=production', 'tier notin (frontend,backend)'")
 	flags.Int32Var(&cmOptions.DeploymentReplicas, "deployment-replicas", 0,
 		"Number of deployment replicas, operator will automatically determine replicas if not set")
+	flags.BoolVar(&cmOptions.EnableSyncLabels, "enable-sync-labels", false,
+		"If set, will sync the labels of Klusterlet CR to all agent resources")
 	opts.AddFlags(flags)
 	return cmd
 }

--- a/pkg/operator/helpers/chart/config.go
+++ b/pkg/operator/helpers/chart/config.go
@@ -31,6 +31,9 @@ type ClusterManagerChartConfig struct {
 	CreateBootstrapSA bool `json:"createBootstrapSA,omitempty"`
 	// ClusterManager is the configuration of clusterManager CR
 	ClusterManager ClusterManagerConfig `json:"clusterManager,omitempty"`
+
+	// EnableSyncLabels is to enable the feature which can sync the labels from clustermanager to all hub resources.
+	EnableSyncLabels bool `json:"enableSyncLabels,omitempty"`
 }
 
 type KlusterletChartConfig struct {

--- a/pkg/operator/helpers/helpers.go
+++ b/pkg/operator/helpers/helpers.go
@@ -53,7 +53,8 @@ const (
 	DefaultAddonNamespace = "open-cluster-management-agent-addon"
 
 	// AgentLabelKey is used to filter resources in informers
-	AgentLabelKey = "createdByKlusterlet"
+	AgentLabelKey          = "createdByKlusterlet"
+	ClusterManagerLabelKey = "createdByClusterManager"
 )
 
 const (
@@ -828,6 +829,15 @@ func GetKlusterletAgentLabels(klusterlet *operatorapiv1.Klusterlet) map[string]s
 	// This label key is used to filter resources in deployment informer
 	labels[AgentLabelKey] = klusterlet.GetName()
 
+	return labels
+}
+
+func GetClusterManagerLabels(cm *operatorapiv1.ClusterManager) map[string]string {
+	labels := cm.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[ClusterManagerLabelKey] = cm.GetName()
 	return labels
 }
 

--- a/pkg/operator/helpers/helpers.go
+++ b/pkg/operator/helpers/helpers.go
@@ -837,7 +837,7 @@ func GetClusterManagerLabels(cm *operatorapiv1.ClusterManager) map[string]string
 	if labels == nil {
 		labels = map[string]string{}
 	}
-	labels[ClusterManagerLabelKey] = cm.GetName()
+
 	return labels
 }
 

--- a/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
+++ b/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
@@ -226,6 +226,7 @@ func (n *clusterManagerController) sync(ctx context.Context, controllerContext f
 	}
 
 	if n.enableSyncLabels {
+		fmt.Printf("get cluster manager labels: %v", helpers.GetClusterManagerLabels(clusterManager))
 		config.Labels = helpers.GetClusterManagerLabels(clusterManager)
 	}
 

--- a/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
+++ b/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	errorhelpers "errors"
+	"fmt"
 	"os"
 	"strings"
 	"time"

--- a/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
+++ b/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
@@ -63,6 +63,7 @@ type clusterManagerController struct {
 	controlPlaneNodeLabelSelector string
 	deploymentReplicas            int32
 	operatorNamespace             string
+	enableSyncLabels              bool
 }
 
 type clusterManagerReconcile interface {
@@ -90,6 +91,7 @@ func NewClusterManagerController(
 	controlPlaneNodeLabelSelector string,
 	deploymentReplicas int32,
 	operatorNamespace string,
+	enableSyncLabels bool,
 ) factory.Controller {
 	controller := &clusterManagerController{
 		operatorKubeClient: operatorKubeClient,
@@ -107,6 +109,7 @@ func NewClusterManagerController(
 		controlPlaneNodeLabelSelector: controlPlaneNodeLabelSelector,
 		deploymentReplicas:            deploymentReplicas,
 		operatorNamespace:             operatorNamespace,
+		enableSyncLabels:              enableSyncLabels,
 	}
 
 	return factory.New().WithSync(controller.sync).
@@ -220,6 +223,10 @@ func (n *clusterManagerController) sync(ctx context.Context, controllerContext f
 	if clusterManager.Spec.DeployOption.Hosted != nil {
 		config.RegistrationWebhook = convertWebhookConfiguration(clusterManager.Spec.DeployOption.Hosted.RegistrationWebhookConfiguration)
 		config.WorkWebhook = convertWebhookConfiguration(clusterManager.Spec.DeployOption.Hosted.WorkWebhookConfiguration)
+	}
+
+	if n.enableSyncLabels {
+		config.Labels = helpers.GetClusterManagerLabels(clusterManager)
 	}
 
 	// Update finalizer at first

--- a/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller_test.go
+++ b/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller_test.go
@@ -279,10 +279,15 @@ func setup(t *testing.T, tc *testController, cd []runtime.Object, crds ...runtim
 	}
 }
 
-func ensureObject(t *testing.T, object runtime.Object, hubCore *operatorapiv1.ClusterManager) {
+func ensureObject(t *testing.T, object runtime.Object, hubCore *operatorapiv1.ClusterManager, enableSyncLabels bool) {
 	access, err := meta.Accessor(object)
 	if err != nil {
 		t.Errorf("Unable to access objectmeta: %v", err)
+	}
+
+	if enableSyncLabels && !helpers.MapCompare(helpers.GetClusterManagerLabels(hubCore), access.GetLabels()) {
+		t.Errorf("the labels of the clustermanager are not synced to %v %v %v", access.GetName(), hubCore.GetLabels(), access.GetLabels())
+		return
 	}
 
 	switch o := object.(type) { //nolint:gocritic
@@ -430,6 +435,7 @@ func TestSyncSecret(t *testing.T) {
 // TestSyncDeploy tests sync manifests of hub component
 func TestSyncDeploy(t *testing.T) {
 	clusterManager := newClusterManager("testhub")
+	clusterManager.SetLabels(map[string]string{"test": "test", "createdByClusterManager": "testhub", "abc": "abc"})
 	tc := newTestController(t, clusterManager)
 	clusterManagerNamespace := helpers.ClusterManagerNamespace(clusterManager.Name, clusterManager.Spec.DeployOption.Mode)
 	cd := setDeployment(clusterManager.Name, clusterManagerNamespace)
@@ -455,7 +461,7 @@ func TestSyncDeploy(t *testing.T) {
 	// We expect create the namespace twice respectively in the management cluster and the hub cluster.
 	testingcommon.AssertEqualNumber(t, len(createKubeObjects), 28)
 	for _, object := range createKubeObjects {
-		ensureObject(t, object, clusterManager)
+		ensureObject(t, object, clusterManager, false)
 	}
 
 	var createCRDObjects []runtime.Object
@@ -495,7 +501,7 @@ func TestSyncDeployNoWebhook(t *testing.T) {
 	// We expect create the namespace twice respectively in the management cluster and the hub cluster.
 	testingcommon.AssertEqualNumber(t, len(createKubeObjects), 30)
 	for _, object := range createKubeObjects {
-		ensureObject(t, object, clusterManager)
+		ensureObject(t, object, clusterManager, false)
 	}
 
 	var createCRDObjects []runtime.Object

--- a/pkg/operator/operators/clustermanager/options.go
+++ b/pkg/operator/operators/clustermanager/options.go
@@ -26,6 +26,7 @@ type Options struct {
 	SkipRemoveCRDs                bool
 	ControlPlaneNodeLabelSelector string
 	DeploymentReplicas            int32
+	EnableSyncLabels              bool
 }
 
 // RunClusterManagerOperator starts a new cluster manager operator

--- a/pkg/operator/operators/clustermanager/options.go
+++ b/pkg/operator/operators/clustermanager/options.go
@@ -81,6 +81,7 @@ func (o *Options) RunClusterManagerOperator(ctx context.Context, controllerConte
 		o.ControlPlaneNodeLabelSelector,
 		o.DeploymentReplicas,
 		controllerContext.OperatorNamespace,
+		o.EnableSyncLabels,
 	)
 
 	statusController := clustermanagerstatuscontroller.NewClusterManagerStatusController(

--- a/pkg/registration/helpers/helpers.go
+++ b/pkg/registration/helpers/helpers.go
@@ -86,7 +86,7 @@ func ManagedClusterAssetFnWithAccepted(fs embed.FS, managedClusterName string, a
 		}{
 			ManagedClusterName: managedClusterName,
 			Accepted:           accepted,
-			Labels:             parseLabels(labels),
+			Labels:             ParseLabels(labels),
 		}
 
 		template, err := fs.ReadFile(name)
@@ -180,20 +180,19 @@ func IsCSRSupported(nativeClient kubernetes.Interface) (bool, bool, error) {
 	return v1CSRSupported, v1beta1CSRSupported, nil
 }
 
-
-func parseLabels(labels string) map[string]string {
-    parsedLabels := make(map[string]string)
-    if labels == "" {
-        return parsedLabels
-    }
-    // Split the labels by comma
-    labelsList := strings.Split(labels, ",")
-    // Iterate over each label and split by '='
-    for _, label := range labelsList {  
-        parts := strings.SplitN(label, "=", 2)
-        if len(parts) == 2 {
-            parsedLabels[parts[0]] = parts[1]
-        } 
-    }
-    return parsedLabels
+func ParseLabels(labels string) map[string]string {
+	parsedLabels := make(map[string]string)
+	if labels == "" {
+		return parsedLabels
+	}
+	// Split the labels by comma
+	labelsList := strings.Split(labels, ",")
+	// Iterate over each label and split by '='
+	for _, label := range labelsList {
+		parts := strings.SplitN(label, "=", 2)
+		if len(parts) == 2 {
+			parsedLabels[parts[0]] = parts[1]
+		}
+	}
+	return parsedLabels
 }

--- a/pkg/registration/helpers/helpers.go
+++ b/pkg/registration/helpers/helpers.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"embed"
 	"net/url"
+	"strings"
 
 	"github.com/openshift/library-go/pkg/assets"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
@@ -76,14 +77,16 @@ func ManagedClusterAssetFn(fs embed.FS, managedClusterName string) resourceapply
 	}
 }
 
-func ManagedClusterAssetFnWithAccepted(fs embed.FS, managedClusterName string, accepted bool) resourceapply.AssetFunc {
+func ManagedClusterAssetFnWithAccepted(fs embed.FS, managedClusterName string, accepted bool, labels string) resourceapply.AssetFunc {
 	return func(name string) ([]byte, error) {
 		config := struct {
 			ManagedClusterName string
 			Accepted           bool
+			Labels             map[string]string
 		}{
 			ManagedClusterName: managedClusterName,
 			Accepted:           accepted,
+			Labels:             parseLabels(labels),
 		}
 
 		template, err := fs.ReadFile(name)
@@ -175,4 +178,22 @@ func IsCSRSupported(nativeClient kubernetes.Interface) (bool, bool, error) {
 		}
 	}
 	return v1CSRSupported, v1beta1CSRSupported, nil
+}
+
+
+func parseLabels(labels string) map[string]string {
+    parsedLabels := make(map[string]string)
+    if labels == "" {
+        return parsedLabels
+    }
+    // Split the labels by comma
+    labelsList := strings.Split(labels, ",")
+    // Iterate over each label and split by '='
+    for _, label := range labelsList {  
+        parts := strings.SplitN(label, "=", 2)
+        if len(parts) == 2 {
+            parsedLabels[parts[0]] = parts[1]
+        } 
+    }
+    return parsedLabels
 }

--- a/pkg/registration/helpers/helpers_test.go
+++ b/pkg/registration/helpers/helpers_test.go
@@ -287,7 +287,7 @@ func TestParseLabels(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual := parseLabels(c.input)
+			actual := ParseLabels(c.input)
 			if !reflect.DeepEqual(actual, c.expected) {
 				t.Errorf("expected %v, got %v", c.expected, actual)
 			}

--- a/pkg/registration/helpers/helpers_test.go
+++ b/pkg/registration/helpers/helpers_test.go
@@ -245,3 +245,52 @@ func TestRemoveTaints(t *testing.T) {
 		})
 	}
 }
+
+// Unit test for parseLabels
+func TestParseLabels(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected map[string]string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: map[string]string{},
+		},
+		{
+			name:     "single label",
+			input:    "key=value",
+			expected: map[string]string{"key": "value"},
+		},
+		{
+			name:     "multiple labels",
+			input:    "key1=value1,key2=value2",
+			expected: map[string]string{"key1": "value1", "key2": "value2"},
+		},
+		{
+			name:     "label with missing value",
+			input:    "key1=,key2=value2",
+			expected: map[string]string{"key1": "", "key2": "value2"},
+		},
+		{
+			name:     "label with extra equals",
+			input:    "key1=value=extra,key2=value2",
+			expected: map[string]string{"key1": "value=extra", "key2": "value2"},
+		},
+		{
+			name:     "label with no equals",
+			input:    "key1,key2=value2",
+			expected: map[string]string{"key2": "value2"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual := parseLabels(c.input)
+			if !reflect.DeepEqual(actual, c.expected) {
+				t.Errorf("expected %v, got %v", c.expected, actual)
+			}
+		})
+	}
+}

--- a/pkg/registration/hub/clusterrole/controller.go
+++ b/pkg/registration/hub/clusterrole/controller.go
@@ -73,13 +73,15 @@ func (c *clusterroleController) sync(ctx context.Context, syncCtx factory.SyncCo
 	}
 
 	var errs []error
+	assetFn := helpers.ManagedClusterAssetFnWithAccepted(manifests.RBACManifests, "", false, c.labels)
+
 	// Clean up managedcluser cluserroles if there are no managed clusters
 	if len(managedClusters) == 0 {
 		results := resourceapply.DeleteAll(
 			ctx,
 			resourceapply.NewKubeClientHolder(c.kubeClient),
 			c.eventRecorder,
-			manifests.RBACManifests.ReadFile,
+			assetFn,
 			manifests.CommonClusterRoleFiles...,
 		)
 		for _, result := range results {
@@ -94,7 +96,7 @@ func (c *clusterroleController) sync(ctx context.Context, syncCtx factory.SyncCo
 	results := c.applier.Apply(
 		ctx,
 		syncCtx.Recorder(),
-		helpers.ManagedClusterAssetFnWithAccepted(manifests.RBACManifests, "", false, c.labels),
+		assetFn,
 		manifests.CommonClusterRoleFiles...,
 	)
 

--- a/pkg/registration/hub/clusterrole/controller_test.go
+++ b/pkg/registration/hub/clusterrole/controller_test.go
@@ -2,6 +2,7 @@ package clusterrole
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -23,10 +24,15 @@ import (
 )
 
 func TestSyncManagedClusterClusterRole(t *testing.T) {
+	const (
+		testCustomLabel      = "custom-label"
+		testCustomLabelValue = "custom-value"
+	)
 	cases := []struct {
 		name            string
 		clusters        []runtime.Object
 		clusterroles    []runtime.Object
+		labels          string
 		validateActions func(t *testing.T, actions []clienttesting.Action)
 	}{
 		{
@@ -62,6 +68,30 @@ func TestSyncManagedClusterClusterRole(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:         "add labels to created clusterroles",
+			clusters:     []runtime.Object{testinghelpers.NewManagedCluster()},
+			clusterroles: []runtime.Object{},
+			labels:       fmt.Sprintf("%s=%s", testCustomLabel, testCustomLabelValue),
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				testingcommon.AssertActions(t, actions, "create", "create")
+				registrationClusterRole := (actions[0].(clienttesting.CreateActionImpl).Object).(*rbacv1.ClusterRole)
+				if registrationClusterRole.Name != "open-cluster-management:managedcluster:registration" {
+					t.Errorf("expected registration clusterrole, but failed")
+				}
+				if registrationClusterRole.Labels[testCustomLabel] != testCustomLabelValue {
+					t.Errorf("expected label '%s=%s' on registration clusterrole, but not found", testCustomLabel, testCustomLabelValue)
+				}
+
+				workClusterRole := (actions[1].(clienttesting.CreateActionImpl).Object).(*rbacv1.ClusterRole)
+				if workClusterRole.Name != "open-cluster-management:managedcluster:work" {
+					t.Errorf("expected work clusterrole, but failed")
+				}
+				if workClusterRole.Labels[testCustomLabel] != testCustomLabelValue {
+					t.Errorf("expected label '%s=%s' on work clusterrole, but not found", testCustomLabel, testCustomLabelValue)
+				}
+			},
+		},
 	}
 
 	for _, c := range cases {
@@ -90,6 +120,7 @@ func TestSyncManagedClusterClusterRole(t *testing.T) {
 				clusterLister: clusterInformerFactory.Cluster().V1().ManagedClusters().Lister(),
 				cache:         resourceapply.NewResourceCache(),
 				eventRecorder: eventstesting.NewTestingEventRecorder(t),
+				labels:        c.labels,
 			}
 
 			syncErr := ctrl.sync(context.TODO(), testingcommon.NewFakeSyncContext(t, "testmangedclsuterclusterrole"))

--- a/pkg/registration/hub/managedcluster/controller.go
+++ b/pkg/registration/hub/managedcluster/controller.go
@@ -62,7 +62,7 @@ type managedClusterController struct {
 	patcher            patcher.Patcher[*v1.ManagedCluster, v1.ManagedClusterSpec, v1.ManagedClusterStatus]
 	hubDriver          register.HubDriver
 	eventRecorder      events.Recorder
-	labels			   string
+	labels             string
 }
 
 // NewManagedClusterController creates a new managed cluster controller
@@ -96,7 +96,7 @@ func NewManagedClusterController(
 			*v1.ManagedCluster, v1.ManagedClusterSpec, v1.ManagedClusterStatus](
 			clusterClient.ClusterV1().ManagedClusters()),
 		eventRecorder: recorder.WithComponentSuffix("managed-cluster-controller"),
-		labels:    labels,
+		labels:        labels,
 	}
 	return factory.New().
 		WithInformersQueueKeysFunc(queue.QueueKeyByMetaName, clusterInformer.Informer()).
@@ -208,7 +208,7 @@ func (c *managedClusterController) sync(ctx context.Context, syncCtx factory.Syn
 	// 2. cluster specific rbac resources for this spoke cluster.(hubAcceptsClient=true)
 	// 3. cluster specific rolebinding(registration-agent and work-agent) for this spoke cluster.
 	var errs []error
-	_, _, err = resourceapply.ApplyNamespace(ctx, c.kubeClient.CoreV1(), syncCtx.Recorder(), namespace)
+	_, _, err = resourceapply.ApplyNamespace(ctx, c.kubeClient.CoreV1(), syncCtx.Recorder(), namespace) //TODO: Pass labels here as well
 	if err != nil {
 		errs = append(errs, err)
 	}

--- a/pkg/registration/hub/managedcluster/controller_test.go
+++ b/pkg/registration/hub/managedcluster/controller_test.go
@@ -263,7 +263,8 @@ func TestSyncManagedCluster(t *testing.T) {
 				),
 				patcher.NewPatcher[*v1.ManagedCluster, v1.ManagedClusterSpec, v1.ManagedClusterStatus](clusterClient.ClusterV1().ManagedClusters()),
 				register.NewNoopHubDriver(),
-				eventstesting.NewTestingEventRecorder(t)}
+				eventstesting.NewTestingEventRecorder(t),
+				""}
 			syncErr := ctrl.sync(context.TODO(), testingcommon.NewFakeSyncContext(t, testinghelpers.TestManagedClusterName))
 			if syncErr != nil && !errors.Is(syncErr, requeueError) {
 				t.Errorf("unexpected err: %v", syncErr)

--- a/pkg/registration/hub/managedcluster/controller_test.go
+++ b/pkg/registration/hub/managedcluster/controller_test.go
@@ -35,8 +35,10 @@ import (
 
 func TestSyncManagedCluster(t *testing.T) {
 	const (
-		testCustomLabel      = "custom-label"
-		testCustomLabelValue = "custom-value"
+		testCustomLabel       = "custom-label"
+		testCustomLabelValue  = "custom-value"
+		testCustomLabel2      = "custom-label2"
+		testCustomLabelValue2 = "custom-value2"
 	)
 	cases := []struct {
 		name                   string
@@ -225,7 +227,7 @@ func TestSyncManagedCluster(t *testing.T) {
 			validateClusterActions: func(t *testing.T, actions []clienttesting.Action) {
 				testingcommon.AssertNoActions(t, actions)
 			},
-			labels: fmt.Sprintf("%s=%s", testCustomLabel, testCustomLabelValue),
+			labels: fmt.Sprintf("%s=%s,%s=%s", testCustomLabel, testCustomLabelValue, testCustomLabel2, testCustomLabelValue2),
 			validateKubeActions: func(t *testing.T, actions []clienttesting.Action) {
 				testingcommon.AssertActions(t, actions,
 					"get", "create", // namespace
@@ -239,11 +241,17 @@ func TestSyncManagedCluster(t *testing.T) {
 				if namespace.Labels[testCustomLabel] != testCustomLabelValue {
 					t.Errorf("expected label '%s=%s' on namespace, but got: %v", testCustomLabel, testCustomLabelValue, namespace.Labels)
 				}
+				if namespace.Labels[testCustomLabel2] != testCustomLabelValue2 {
+					t.Errorf("expected label '%s=%s' on namespace, but got: %v", testCustomLabel2, testCustomLabelValue2, namespace.Labels)
+				}
 
 				// Validate labels on clusterrole
 				clusterRole := actions[2].(clienttesting.CreateAction).GetObject().(*rbacv1.ClusterRole)
 				if clusterRole.Labels[testCustomLabel] != testCustomLabelValue {
 					t.Errorf("expected label '%s=%s' on clusterrole, but got: %v", testCustomLabel, testCustomLabelValue, clusterRole.Labels)
+				}
+				if clusterRole.Labels[testCustomLabel2] != testCustomLabelValue2 {
+					t.Errorf("expected label '%s=%s' on clusterrole, but got: %v", testCustomLabel2, testCustomLabelValue2, clusterRole.Labels)
 				}
 
 				// Validate labels on clusterrolebinding
@@ -251,17 +259,26 @@ func TestSyncManagedCluster(t *testing.T) {
 				if clusterRoleBinding.Labels[testCustomLabel] != testCustomLabelValue {
 					t.Errorf("expected label '%s=%s' on clusterrolebinding, but got: %v", testCustomLabel, testCustomLabelValue, clusterRoleBinding.Labels)
 				}
+				if clusterRoleBinding.Labels[testCustomLabel2] != testCustomLabelValue2 {
+					t.Errorf("expected label '%s=%s' on clusterrolebinding, but got: %v", testCustomLabel2, testCustomLabelValue2, clusterRoleBinding.Labels)
+				}
 
 				// Validate labels on registration rolebinding
 				registrationRoleBinding := actions[4].(clienttesting.CreateAction).GetObject().(*rbacv1.RoleBinding)
 				if registrationRoleBinding.Labels[testCustomLabel] != testCustomLabelValue {
 					t.Errorf("expected label '%s=%s' on registration rolebinding, but got: %v", testCustomLabel, testCustomLabelValue, registrationRoleBinding.Labels)
 				}
+				if registrationRoleBinding.Labels[testCustomLabel2] != testCustomLabelValue2 {
+					t.Errorf("expected label '%s=%s' on registration rolebinding, but got: %v", testCustomLabel2, testCustomLabelValue2, registrationRoleBinding.Labels)
+				}
 
 				// Validate labels on work rolebinding
 				workRoleBinding := actions[5].(clienttesting.CreateAction).GetObject().(*rbacv1.RoleBinding)
 				if workRoleBinding.Labels[testCustomLabel] != testCustomLabelValue {
 					t.Errorf("expected label '%s=%s' on work rolebinding, but got: %v", testCustomLabel, testCustomLabelValue, workRoleBinding.Labels)
+				}
+				if workRoleBinding.Labels[testCustomLabel2] != testCustomLabelValue2 {
+					t.Errorf("expected label '%s=%s' on work rolebinding, but got: %v", testCustomLabel2, testCustomLabelValue2, workRoleBinding.Labels)
 				}
 			},
 		},

--- a/pkg/registration/hub/manager.go
+++ b/pkg/registration/hub/manager.go
@@ -2,7 +2,6 @@ package hub
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
@@ -94,7 +93,6 @@ func (m *HubManagerOptions) AddFlags(fs *pflag.FlagSet) {
 		"Labels to be added to the resources created by registration controller. The format is key1=value1,key2=value2.")
 	m.ImportOption.AddFlags(fs)
 }
-
 
 // RunControllerManager starts the controllers on hub to manage spoke cluster registration.
 func (m *HubManagerOptions) RunControllerManager(ctx context.Context, controllerContext *controllercmd.ControllerContext) error {
@@ -254,6 +252,7 @@ func (m *HubManagerOptions) RunControllerManagerWithInformers(
 		clusterInformers.Cluster().V1().ManagedClusters(),
 		kubeInformers.Rbac().V1().ClusterRoles(),
 		controllerContext.EventRecorder,
+		m.Labels,
 	)
 
 	addOnHealthCheckController := addon.NewManagedClusterAddOnHealthCheckController(

--- a/pkg/registration/hub/manager.go
+++ b/pkg/registration/hub/manager.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
@@ -56,6 +57,7 @@ type HubManagerOptions struct {
 	AutoApprovedCSRUsers       []string
 	AutoApprovedARNPatterns    []string
 	AwsResourceTags            []string
+	Labels                     string
 }
 
 // NewHubManagerOptions returns a HubManagerOptions
@@ -88,8 +90,11 @@ func (m *HubManagerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVar(&m.AutoApprovedARNPatterns, "auto-approved-arn-patterns", m.AutoApprovedARNPatterns,
 		"A list of AWS EKS ARN patterns such that an EKS cluster will be auto approved if its ARN matches with any of the patterns")
 	fs.StringSliceVar(&m.AwsResourceTags, "aws-resource-tags", m.AwsResourceTags, "A list of tags to apply to AWS resources created through the OCM controllers")
+	fs.StringVar(&m.Labels, "labels", m.Labels,
+		"Labels to be added to the resources created by registration controller. The format is key1=value1,key2=value2.")
 	m.ImportOption.AddFlags(fs)
 }
+
 
 // RunControllerManager starts the controllers on hub to manage spoke cluster registration.
 func (m *HubManagerOptions) RunControllerManager(ctx context.Context, controllerContext *controllercmd.ControllerContext) error {
@@ -201,6 +206,7 @@ func (m *HubManagerOptions) RunControllerManagerWithInformers(
 		workInformers.Work().V1().ManifestWorks(),
 		hubDriver,
 		controllerContext.EventRecorder,
+		m.Labels,
 	)
 
 	taintController := taint.NewTaintController(

--- a/pkg/registration/hub/manifests/rbac/managedcluster-clusterrole.yaml
+++ b/pkg/registration/hub/manifests/rbac/managedcluster-clusterrole.yaml
@@ -4,6 +4,11 @@ metadata:
   name: open-cluster-management:managedcluster:{{ .ManagedClusterName }}
   labels:
     open-cluster-management.io/cluster-name: "{{ .ManagedClusterName }}"
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 rules:
 {{- if .Accepted }}
 # Allow agent to rotate its certificate

--- a/pkg/registration/hub/manifests/rbac/managedcluster-clusterrolebinding.yaml
+++ b/pkg/registration/hub/manifests/rbac/managedcluster-clusterrolebinding.yaml
@@ -4,6 +4,11 @@ metadata:
   name: open-cluster-management:managedcluster:{{ .ManagedClusterName }}
   labels:
     open-cluster-management.io/cluster-name: "{{ .ManagedClusterName }}"
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/pkg/registration/hub/manifests/rbac/managedcluster-registration-clusterrole.yaml
+++ b/pkg/registration/hub/manifests/rbac/managedcluster-registration-clusterrole.yaml
@@ -4,6 +4,11 @@ metadata:
   name: open-cluster-management:managedcluster:registration
   labels:
     open-cluster-management.io/cluster-name: ""
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 rules:
 # Allow spoke registration agent to get/update coordination.k8s.io/lease
 - apiGroups: ["coordination.k8s.io"]

--- a/pkg/registration/hub/manifests/rbac/managedcluster-registration-rolebinding.yaml
+++ b/pkg/registration/hub/manifests/rbac/managedcluster-registration-rolebinding.yaml
@@ -5,6 +5,11 @@ metadata:
   namespace: "{{ .ManagedClusterName }}"
   labels:
     open-cluster-management.io/cluster-name: "{{ .ManagedClusterName }}"
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/pkg/registration/hub/manifests/rbac/managedcluster-work-clusterrole.yaml
+++ b/pkg/registration/hub/manifests/rbac/managedcluster-work-clusterrole.yaml
@@ -4,6 +4,11 @@ metadata:
   name: open-cluster-management:managedcluster:work
   labels:
     open-cluster-management.io/cluster-name: ""
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 rules:
 # Allow work agent to send event to hub
 - apiGroups: ["", "events.k8s.io"]

--- a/pkg/registration/hub/manifests/rbac/managedcluster-work-rolebinding.yaml
+++ b/pkg/registration/hub/manifests/rbac/managedcluster-work-rolebinding.yaml
@@ -5,6 +5,11 @@ metadata:
   namespace: "{{ .ManagedClusterName }}"
   labels:
     open-cluster-management.io/cluster-name: "{{ .ManagedClusterName }}"
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
   finalizers:
   - cluster.open-cluster-management.io/manifest-work-cleanup
 roleRef:

--- a/test/integration/operator/integration_suite_test.go
+++ b/test/integration/operator/integration_suite_test.go
@@ -129,6 +129,11 @@ var _ = ginkgo.BeforeSuite(func() {
 	_, err = operatorClient.OperatorV1().ClusterManagers().Create(context.Background(), &operatorapiv1.ClusterManager{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: clusterManagerName,
+			Labels: map[string]string {
+				"app": "clustermanager",
+				"labelOne": "valueOne",
+				"labelTwo": "valueTwo",
+			},
 		},
 		Spec: operatorapiv1.ClusterManagerSpec{
 			RegistrationImagePullSpec: "quay.io/open-cluster-management/registration",
@@ -158,6 +163,11 @@ var _ = ginkgo.BeforeSuite(func() {
 	_, err = hostedOperatorClient.OperatorV1().ClusterManagers().Create(context.Background(), &operatorapiv1.ClusterManager{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: clusterManagerName,
+			Labels: map[string]string {
+				"app": "clustermanager",
+				"labelOne": "valueOne",
+				"labelTwo": "valueTwo",
+			},
 		},
 		Spec: operatorapiv1.ClusterManagerSpec{
 			RegistrationImagePullSpec: "quay.io/open-cluster-management/registration",

--- a/test/integration/registration/integration_suite_test.go
+++ b/test/integration/registration/integration_suite_test.go
@@ -37,8 +37,12 @@ import (
 )
 
 const (
-	eventuallyTimeout  = 30 // seconds
-	eventuallyInterval = 1  // seconds
+	eventuallyTimeout     = 30 // seconds
+	eventuallyInterval    = 1  // seconds
+	testCustomLabel       = "custom-label"
+	testCustomLabelValue  = "custom-value"
+	testCustomLabel2      = "custom-label2"
+	testCustomLabelValue2 = "custom-value2"
 )
 
 var spokeCfg *rest.Config
@@ -214,6 +218,7 @@ var _ = ginkgo.BeforeSuite(func() {
 			m.HubClusterArn = "arn:aws:eks:us-west-2:123456789012:cluster/hub-cluster1"
 			m.ClusterAutoApprovalUsers = []string{util.AutoApprovalBootstrapUser}
 			m.AutoApprovedARNPatterns = []string{"arn:aws:eks:us-west-2:123456789012:cluster/.*"}
+			m.Labels = fmt.Sprintf("%s=%s,%s=%s", testCustomLabel, testCustomLabelValue, testCustomLabel2, testCustomLabelValue2)
 			err := m.RunControllerManager(ctx, &controllercmd.ControllerContext{
 				KubeConfig:    cfg,
 				EventRecorder: util.NewIntegrationTestEventRecorder("hub"),

--- a/test/integration/registration/managedcluster_accept_test.go
+++ b/test/integration/registration/managedcluster_accept_test.go
@@ -45,24 +45,45 @@ var _ = Describe("ManagedCluster set hubAcceptsClient from true to false", Label
 			if len(clusterRole.Rules) != 4 {
 				return fmt.Errorf("expected 4 rules, got %d rules", len(clusterRole.Rules))
 			}
+			if clusterRole.Labels[testCustomLabel] != testCustomLabelValue || clusterRole.Labels[testCustomLabel2] != testCustomLabelValue {
+				return fmt.Errorf("clusterRole %s does not have expected labels", mclClusterRoleName(managedCluster.Name))
+			}
 
 			return nil
 		}, eventuallyTimeout, eventuallyInterval).Should(Succeed())
 
 		Eventually(func() error {
-			_, err := kubeClient.RbacV1().ClusterRoleBindings().Get(context.Background(), mclClusterRoleBindingName(managedCluster.Name), metav1.GetOptions{})
-			return err
+			clusterRoleBinding, err := kubeClient.RbacV1().ClusterRoleBindings().Get(context.Background(), mclClusterRoleBindingName(managedCluster.Name), metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if clusterRoleBinding.Labels[testCustomLabel] != testCustomLabelValue || clusterRoleBinding.Labels[testCustomLabel2] != testCustomLabelValue {
+				return fmt.Errorf("clusterRoleBinding %s does not have expected labels", mclClusterRoleBindingName(managedCluster.Name))
+			}
+			return nil
 		}, eventuallyTimeout, eventuallyInterval).Should(Succeed())
 
 		Eventually(func() error {
-			_, err := kubeClient.RbacV1().RoleBindings(managedCluster.Name).
+			registrationRoleBinding, err := kubeClient.RbacV1().RoleBindings(managedCluster.Name).
 				Get(context.Background(), registrationRoleBindingName(managedCluster.Name), metav1.GetOptions{})
-			return err
+			if err != nil {
+				return err
+			}
+			if registrationRoleBinding.Labels[testCustomLabel] != testCustomLabelValue || registrationRoleBinding.Labels[testCustomLabel2] != testCustomLabelValue {
+				return fmt.Errorf("roleBinding %s does not have expected labels", registrationRoleBindingName(managedCluster.Name))
+			}
+			return nil
 		}, eventuallyTimeout, eventuallyInterval).Should(Succeed())
 
 		Eventually(func() error {
-			_, err := kubeClient.RbacV1().RoleBindings(managedCluster.Name).Get(context.Background(), workRoleBindingName(managedCluster.Name), metav1.GetOptions{})
-			return err
+			workRoleBinding, err := kubeClient.RbacV1().RoleBindings(managedCluster.Name).Get(context.Background(), workRoleBindingName(managedCluster.Name), metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if workRoleBinding.Labels[testCustomLabel] != testCustomLabelValue || workRoleBinding.Labels[testCustomLabel2] != testCustomLabelValue {
+				return fmt.Errorf("workRoleBinding %s does not have expected labels", workRoleBindingName(managedCluster.Name))
+			}
+			return nil
 		}, eventuallyTimeout, eventuallyInterval).Should(Succeed())
 	})
 

--- a/test/integration/registration/managedcluster_accept_test.go
+++ b/test/integration/registration/managedcluster_accept_test.go
@@ -3,14 +3,13 @@ package registration_test
 import (
 	"context"
 	"fmt"
-	"reflect"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"reflect"
 
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 )
@@ -29,14 +28,20 @@ var _ = Describe("ManagedCluster set hubAcceptsClient from true to false", Label
 		}
 		_, err := clusterClient.ClusterV1().ManagedClusters().Create(context.Background(), managedCluster, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
-
-		// Check rbac files should be created
+		//Checks if the namespace has the required labels
 		Eventually(func() error {
-			_, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), mclClusterRoleName(managedCluster.Name), metav1.GetOptions{})
+			namespace, err := kubeClient.CoreV1().Namespaces().Get(context.Background(), managedCluster.Name, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
+			if namespace.Labels != nil && namespace.Labels[testCustomLabel] != "" && namespace.Labels[testCustomLabel] != testCustomLabelValue || namespace.Labels[testCustomLabel2] != testCustomLabelValue2 {
+				return fmt.Errorf("namespace %s should  have custom label", managedCluster.Name)
+			}
+			return nil
+		}, eventuallyTimeout, eventuallyInterval).Should(Succeed())
 
+		// Check rbac files should be created
+		Eventually(func() error {
 			// check clusterrole is correct
 			clusterRole, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), mclClusterRoleName(managedCluster.Name), metav1.GetOptions{})
 			if err != nil {
@@ -45,7 +50,7 @@ var _ = Describe("ManagedCluster set hubAcceptsClient from true to false", Label
 			if len(clusterRole.Rules) != 4 {
 				return fmt.Errorf("expected 4 rules, got %d rules", len(clusterRole.Rules))
 			}
-			if clusterRole.Labels[testCustomLabel] != testCustomLabelValue || clusterRole.Labels[testCustomLabel2] != testCustomLabelValue {
+			if clusterRole.Labels[testCustomLabel] != testCustomLabelValue || clusterRole.Labels[testCustomLabel2] != testCustomLabelValue2 {
 				return fmt.Errorf("clusterRole %s does not have expected labels", mclClusterRoleName(managedCluster.Name))
 			}
 
@@ -57,7 +62,7 @@ var _ = Describe("ManagedCluster set hubAcceptsClient from true to false", Label
 			if err != nil {
 				return err
 			}
-			if clusterRoleBinding.Labels[testCustomLabel] != testCustomLabelValue || clusterRoleBinding.Labels[testCustomLabel2] != testCustomLabelValue {
+			if clusterRoleBinding.Labels[testCustomLabel] != testCustomLabelValue || clusterRoleBinding.Labels[testCustomLabel2] != testCustomLabelValue2 {
 				return fmt.Errorf("clusterRoleBinding %s does not have expected labels", mclClusterRoleBindingName(managedCluster.Name))
 			}
 			return nil
@@ -69,7 +74,7 @@ var _ = Describe("ManagedCluster set hubAcceptsClient from true to false", Label
 			if err != nil {
 				return err
 			}
-			if registrationRoleBinding.Labels[testCustomLabel] != testCustomLabelValue || registrationRoleBinding.Labels[testCustomLabel2] != testCustomLabelValue {
+			if registrationRoleBinding.Labels[testCustomLabel] != testCustomLabelValue || registrationRoleBinding.Labels[testCustomLabel2] != testCustomLabelValue2 {
 				return fmt.Errorf("roleBinding %s does not have expected labels", registrationRoleBindingName(managedCluster.Name))
 			}
 			return nil
@@ -80,11 +85,36 @@ var _ = Describe("ManagedCluster set hubAcceptsClient from true to false", Label
 			if err != nil {
 				return err
 			}
-			if workRoleBinding.Labels[testCustomLabel] != testCustomLabelValue || workRoleBinding.Labels[testCustomLabel2] != testCustomLabelValue {
+			if workRoleBinding.Labels[testCustomLabel] != testCustomLabelValue || workRoleBinding.Labels[testCustomLabel2] != testCustomLabelValue2 {
 				return fmt.Errorf("workRoleBinding %s does not have expected labels", workRoleBindingName(managedCluster.Name))
 			}
 			return nil
 		}, eventuallyTimeout, eventuallyInterval).Should(Succeed())
+
+		Eventually(func() error {
+			registrationClusterRole, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), "open-cluster-management:managedcluster:registration", metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if registrationClusterRole.Labels[testCustomLabel] != testCustomLabelValue || registrationClusterRole.Labels[testCustomLabel2] != testCustomLabelValue2 {
+				return fmt.Errorf("clusterRole open-cluster-management:managedcluster:registration does not have expected labels", mclClusterRoleName(managedCluster.Name))
+			}
+
+			return nil
+		}, eventuallyTimeout, eventuallyInterval).Should(Succeed())
+
+		Eventually(func() error {
+			workClusterRole, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), "open-cluster-management:managedcluster:work", metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if workClusterRole.Labels[testCustomLabel] != testCustomLabelValue || workClusterRole.Labels[testCustomLabel2] != testCustomLabelValue2 {
+				return fmt.Errorf("clusterRole open-cluster-management:managedcluster:work does not have expected labels", mclClusterRoleName(managedCluster.Name))
+			}
+
+			return nil
+		}, eventuallyTimeout, eventuallyInterval).Should(Succeed())
+
 	})
 
 	It("should set hubAcceptsClient to false", func() {

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
@@ -248,6 +248,7 @@ func DeleteAll(ctx context.Context, clients *ClientHolder, recorder events.Recor
 			ret = append(ret, result)
 			continue
 		}
+		fmt.Printf("objBytes: %s\n", string(objBytes))
 		requiredObj, err := resourceread.ReadGenericWithUnstructured(objBytes)
 		if err != nil {
 			result.Error = fmt.Errorf("cannot decode %q: %v", file, err)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support to sync ClusterManager labels to all resources created by the ClusterManager operator, controlled by the new enableSyncLabels option.

- **New Features**
  - Added enableSyncLabels flag to the ClusterManager operator and Helm chart.
  - When enabled, ClusterManager labels are applied to all managed resources, including CRDs, RBAC, and deployments.
  - Updated tests to verify label propagation.

<!-- End of auto-generated description by cubic. -->

